### PR TITLE
changed {study.etAl(2)} to {study.etAl(1)}

### DIFF
--- a/client/components/StudiesTable.js
+++ b/client/components/StudiesTable.js
@@ -672,7 +672,7 @@ StudiesTable.cellViews.number = function(ctrl, study) {
   if (year) {
     year = "(" + year + ")";
   }
-  var etAl = <li>{study.etAl(2)} {year}</li>
+  var etAl = <li>{study.etAl(1)} {year}</li>
 
 
   return <ul>


### PR DESCRIPTION
so that author names & year doesn't get cut off in Firefox