### PR TITLE
minify JS in staging and production

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,7 +123,8 @@ module.exports = function (grunt) {
         },
         plugins: [
           new webpack.optimize.OccurenceOrderPlugin(),
-          new webpack.optimize.DedupePlugin()
+          new webpack.optimize.DedupePlugin(),
+          new webpack.optimize.UglifyJsPlugin({minimize: true})
         ]
       },
       test_production: {
@@ -138,7 +139,8 @@ module.exports = function (grunt) {
         },
         plugins: [
           new webpack.optimize.OccurenceOrderPlugin(),
-          new webpack.optimize.DedupePlugin()
+          new webpack.optimize.DedupePlugin(),
+          new webpack.optimize.UglifyJsPlugin({minimize: true})
         ]
       }
     },


### PR DESCRIPTION
Minifying main.js in staging cut JS download time from 1.8 seconds to .5 seconds in staging. Merging into production.